### PR TITLE
Fade out matched blocks

### DIFF
--- a/app/scripts/Block.js
+++ b/app/scripts/Block.js
@@ -24,6 +24,7 @@
       _shape,
       _isBitmap,
       _setBlockPosition,
+      _onDieCompleteCb,
       _onSwapCompleteCb;
 
     var initialize = function(setBlockPosition, x, y, type) {
@@ -147,7 +148,10 @@
     var fadeOut = function() {
       var isFadedOut = (_shape.alpha <= 0);
       if (isFadedOut) {
-        _state = BlockState.GONE;
+        if (_onDieCompleteCb) {
+          _onDieCompleteCb(self);
+          _onDieCompleteCb = null;
+        }
       } else {
         _shape.alpha -= FADE_SPEED;
       }
@@ -192,15 +196,16 @@
 
     self.die = function() {
       _state = BlockState.DYING;
+      return {
+        then: function(onDieComplete) {
+          _onDieCompleteCb = onDieComplete;
+        }
+      };
     };
 
     self.isSitting = function() {
       return _state === BlockState.SITTING || _state === BlockState.CREATING;
     };
-
-    self.isFaded = function() {
-      return _state === BlockState.GONE;
-    }
 
     self.getShape = function() {
       return _shape;

--- a/app/scripts/Block.js
+++ b/app/scripts/Block.js
@@ -7,6 +7,7 @@
 
     var SWAP_SPEED = 1;
     var FALL_SPEED = 1;
+    var FADE_SPEED = 0.05;
     var BLOCK_BITMAPS = [
       'images/assets/gblock_32.png',
       'images/assets/rblock_32.png',
@@ -143,6 +144,14 @@
       };
     };
 
+    var fadeOut = function() {
+      var isFadedOut = (_shape.alpha <= 0);
+      if (isFadedOut) {
+        _state = BlockState.GONE;
+      } else {
+        _shape.alpha -= FADE_SPEED;
+      }
+    }
 
     /////////////////////////////////
     ////// PUBLIC METHODS ///////////
@@ -189,6 +198,10 @@
       return _state === BlockState.SITTING || _state === BlockState.CREATING;
     };
 
+    self.isFaded = function() {
+      return _state === BlockState.GONE;
+    }
+
     self.getShape = function() {
       return _shape;
     };
@@ -200,6 +213,8 @@
         swapToCol(_col + 1);
       } else if (_state === BlockState.FALLING) {
         fallDown();
+      } else if (_state === BlockState.DYING) {
+        fadeOut();
       }
       if (window.DEBUG_MODE) {
         setDebugColor();

--- a/app/scripts/Grid.js
+++ b/app/scripts/Grid.js
@@ -125,14 +125,6 @@
       }
     };
     
-    var removeFadedBlocks = function() {
-      forAllBlocks(function(block, row, col) {
-        if (block.isFaded()) {
-          removeBlock(block);
-        }
-      });
-    };
-
     // make sure the two spots above are empty too
     var canSwapIntoEmptyPosition = function(col, row) {
       for (var rrow = row; rrow > row - 3; rrow--) {
@@ -216,7 +208,9 @@
       matches = matches.filter(isUnique);
       for (var i = 0; i < matches.length; i++) {
         var matchedBlock = matches[i];
-        matchedBlock.die();
+        matchedBlock.die().then(function(block) {
+          removeBlock(block);
+        });
       }
       if (matches.length >= Grid.MIN_ANNOUNCED_COMBO_LENGTH) {
         _announcement.announce(matches.length + ' COMBO');
@@ -313,7 +307,6 @@
       // most ticks, there will be nothing to do, so
       // this is pretty wasteful
       makeBlocksFall();
-      removeFadedBlocks();
       makeBlocksMatch();
       _announcement.tick();
 

--- a/app/scripts/Grid.js
+++ b/app/scripts/Grid.js
@@ -124,6 +124,14 @@
         }
       }
     };
+    
+    var removeFadedBlocks = function() {
+      forAllBlocks(function(block, row, col) {
+        if (block.isFaded()) {
+          removeBlock(block);
+        }
+      });
+    };
 
     // make sure the two spots above are empty too
     var canSwapIntoEmptyPosition = function(col, row) {
@@ -209,7 +217,6 @@
       for (var i = 0; i < matches.length; i++) {
         var matchedBlock = matches[i];
         matchedBlock.die();
-        removeBlock(matchedBlock);
       }
       if (matches.length >= Grid.MIN_ANNOUNCED_COMBO_LENGTH) {
         _announcement.announce(matches.length + ' COMBO');
@@ -306,6 +313,7 @@
       // most ticks, there will be nothing to do, so
       // this is pretty wasteful
       makeBlocksFall();
+      removeFadedBlocks();
       makeBlocksMatch();
       _announcement.tick();
 


### PR DESCRIPTION
Previously when blocks were matched the would be removed instantly.
Now they have an animated fade out. NOTE: This change now uses the
previously unused BlockState GONE.
